### PR TITLE
feat: add basic monitor validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ network_id: "mainnet"
 block_chunk_size: 5
 polling_interval_ms: 10000
 confirmation_blocks: 12
+monitor_config_path: "monitors.yaml"
 
 # Optional: Configuration for the RPC retry policy.
 # If this section is omitted, default values will be used.
@@ -78,6 +79,7 @@ rhai:
 - `confirmation_blocks`: Number of confirmation blocks to wait for before processing to prevent against small reorgs
 - `shutdown_timeout_secs`: Graceful shutdown timeout
 - `rhai`: Security configuration for Rhai script execution
+- `monitor_config_path`: Path to monitor configuration file
 
 ## Logging
 

--- a/config.yaml
+++ b/config.yaml
@@ -3,10 +3,11 @@ rpc_urls:
   - "https://eth.llamarpc.com"
   - "https://1rpc.io/eth"
   - "https://rpc.mevblocker.io"
-network_id: "mainnet"
+network_id: "ethereum"
 block_chunk_size: 5
 polling_interval_ms: 10000
 confirmation_blocks: 12
+monitor_config_path: "monitors.yaml"
 
 # Optional: Configuration for the RPC retry policy.
 # If this section is omitted, default values will be used.

--- a/migrations/20250806120000_create_monitors_table.sql
+++ b/migrations/20250806120000_create_monitors_table.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS monitors (
     monitor_id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
     network TEXT NOT NULL,
-    address TEXT NOT NULL,
+    address TEXT, -- Nullable to support transaction-level monitors
     filter_script TEXT NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP

--- a/monitors.example.yaml
+++ b/monitors.example.yaml
@@ -1,0 +1,75 @@
+# This is an example configuration file for defining monitors.
+# You can copy this file to `monitors.yaml` and update `config.yaml` to point to it.
+
+monitors:
+  # ------------------------------------------------------------------------------------
+  # EXAMPLE 1: Monitoring a Proxy Contract (USDC Transfers)
+  #
+  # This monitor tracks large transfers of the USDC stablecoin on the Ethereum network.
+  # USDC is a proxy contract, which is a very common pattern. This means:
+  #   1. The `address` you monitor is the PROXY address. This is the public address
+  #      that users interact with and where the event logs are emitted.
+  #   2. The ABI required to decode the events is from the IMPLEMENTATION contract.
+  #
+  # When the `issue_abi_loading.md` feature is implemented, you would provide the ABI
+  # for the implementation contract, even while monitoring the proxy address.
+  # ------------------------------------------------------------------------------------
+  - name: "Large USDC Transfers (Ethereum)"
+    # The network ID must match the `network_id` specified in your main `config.yaml`.
+    network: "ethereum"
+    # This is the PROXY contract address for USDC on Ethereum mainnet.
+    address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    # The Rhai script to filter events.
+    # This script will be executed for every log emitted by the specified contract address.
+    #
+    # Available variables:
+    # - `log`: An object containing the decoded log data.
+    #   - `log.name`: The name of the event (e.g., "Transfer").
+    #   - `log.params`: A map of the event's parameters (e.g., `log.params.from`, `log.params.value`).
+    # - `tx`: An object containing the transaction data.
+    #   - `tx.hash`, `tx.from`, `tx.to`, `tx.value`, etc.
+    #
+    # This script checks for the "Transfer" event and ensures the transfer value is
+    # greater than 1,000,000 USDC.
+    # Note: We use `bigint` because token amounts are very large numbers.
+    # The value "1000000000000" represents 1,000,000 USDC, as USDC has 6 decimal places.
+    filter_script: |
+      log.name == "Transfer" && bigint(log.params.value) > bigint("1000000000000")
+
+  # ------------------------------------------------------------------------------------
+  # EXAMPLE 2: Monitoring a Standard Contract (WETH Deposits)
+  #
+  # This is a more straightforward example for a standard, non-proxy contract.
+  # ------------------------------------------------------------------------------------
+  - name: "WETH Deposits (Ethereum)"
+    network: "ethereum"
+    # This is the canonical address for Wrapped Ether (WETH) on Ethereum.
+    address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    # This script triggers for any "Deposit" event on the WETH contract.
+    filter_script: 'log.name == "Deposit"'
+
+  # ------------------------------------------------------------------------------------
+  # EXAMPLE 3: Monitoring Native Token Transfers (ETH)
+  #
+  # This monitor tracks large transfers of the native blockchain token (ETH).
+  # Unlike contract-based tokens (like ERC20s), native token transfers do not
+  # emit events. Instead, we can monitor them by inspecting the transaction fields
+  # directly.
+  #
+  # To monitor all transactions on a network, you can omit the `address` field.
+  # The filter script will then be executed for every transaction.
+  #
+  # In this case, the `log` variable will not be available. You must use the `tx`
+  # object to define your filtering logic.
+  # ------------------------------------------------------------------------------------
+  - name: "Large ETH Transfers (Ethereum)"
+    network: "ethereum"
+    # By omitting the `address`, this monitor will inspect every transaction on the network.
+    # This is ideal for monitoring native currency transfers.
+    # The filter script will check the transaction's `value` field.
+    #
+    # This script checks for transactions where the value is greater than 10 ETH.
+    # Note: We use `bigint` because `tx.value` is a very large number.
+    # The value "10000000000000000000" is 10 ETH in Wei (10 * 10^18).
+    filter_script: |
+      bigint(tx.value) > bigint("10000000000000000000")

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,9 +29,8 @@ pub struct AppConfig {
     /// Network ID for the Ethereum network.
     pub network_id: String,
 
-    /// Optional path to monitor configuration file.
-    #[serde(default)]
-    pub monitor_config_path: Option<String>,
+    /// Path to monitor configuration file.
+    pub monitor_config_path: String,
 
     /// Optional retry configuration.
     #[serde(default)]
@@ -90,6 +89,7 @@ mod tests {
             block_chunk_size: 10
             polling_interval_ms: 1000
             confirmation_blocks: 12
+            monitor_config_path: 'monitors.yaml'
             retry_config:
               max_retry: 5
               backoff_ms: 500
@@ -104,6 +104,7 @@ mod tests {
         assert_eq!(app_config.retry_config.backoff_ms, 500);
         assert_eq!(app_config.retry_config.compute_units_per_second, 50);
         assert_eq!(app_config.rpc_urls[0].to_string(), "http://localhost:8545/");
+        assert_eq!(app_config.monitor_config_path, "monitors.yaml");
     }
 
     #[test]
@@ -115,6 +116,7 @@ mod tests {
             block_chunk_size: 10
             polling_interval_ms: 1000
             confirmation_blocks: 12
+            monitor_config_path: 'monitors.yaml'
         ";
 
         let builder =
@@ -135,6 +137,7 @@ mod tests {
             default_retry_config.compute_units_per_second
         );
         assert_eq!(app_config.shutdown_timeout_secs, 30);
+        assert_eq!(app_config.monitor_config_path, "monitors.yaml");
     }
 
     #[test]
@@ -146,6 +149,7 @@ mod tests {
             block_chunk_size: 11
             polling_interval_ms: 1000
             confirmation_blocks: 12
+            monitor_config_path: 'monitors.yaml'
         ";
 
         let builder =
@@ -164,6 +168,7 @@ mod tests {
             polling_interval_ms: 5000
             block_chunk_size: 10
             confirmation_blocks: 12
+            monitor_config_path: 'monitors.yaml'
         ";
         let builder =
             Config::builder().add_source(config::File::from_str(yaml, config::FileFormat::Yaml));
@@ -182,6 +187,7 @@ mod tests {
             polling_interval_ms: 1000
             confirmation_blocks: 12
             shutdown_timeout_secs: 60
+            monitor_config_path: 'monitors.yaml'
         ";
         let builder =
             Config::builder().add_source(config::File::from_str(yaml, config::FileFormat::Yaml));
@@ -199,6 +205,7 @@ mod tests {
             block_chunk_size: 10
             polling_interval_ms: 1000
             confirmation_blocks: 12
+            monitor_config_path: 'monitors.yaml'
             rhai:
               max_operations: 250000
               max_call_levels: 15
@@ -230,6 +237,7 @@ mod tests {
             block_chunk_size: 10
             polling_interval_ms: 1000
             confirmation_blocks: 12
+            monitor_config_path: 'monitors.yaml'
         ";
 
         let builder =
@@ -268,6 +276,7 @@ mod tests {
             block_chunk_size: 10
             polling_interval_ms: 1000
             confirmation_blocks: 12
+            monitor_config_path: 'monitors.yaml'
             rhai:
               max_operations: 500000
               execution_timeout: 10000
@@ -309,6 +318,7 @@ mod tests {
             block_chunk_size: 10
             polling_interval_ms: 1000
             confirmation_blocks: 12
+            monitor_config_path: 'monitors.yaml'
             rhai:
               max_operations: 'invalid_number'
               execution_timeout: 5000

--- a/src/config/monitor_loader.rs
+++ b/src/config/monitor_loader.rs
@@ -84,6 +84,10 @@ monitors:
     network: "ethereum"
     address: "0x7a250d5630b4cf539739df2c5dacb4c659f2488d"
     filter_script: "log.name == \"Swap\""
+
+  - name: "Native ETH Transfer Monitor"
+    network: "ethereum"
+    filter_script: "bigint(tx.value) > bigint(\"1000000000000000000\")"
 "#
         .trim()
         .to_string()
@@ -106,26 +110,35 @@ monitors:
 
         assert!(result.is_ok());
         let monitors = result.unwrap();
-        assert_eq!(monitors.len(), 2);
+        assert_eq!(monitors.len(), 3);
 
-        // Check first monitor
+        // Check first monitor (with address)
         assert_eq!(monitors[0].name, "USDC Transfer Monitor");
         assert_eq!(monitors[0].network, "ethereum");
         assert_eq!(
             monitors[0].address,
-            "0xa0b86a33e6441b38d4b5e5bfa1bf7a5eb70c5b1e"
+            Some("0xa0b86a33e6441b38d4b5e5bfa1bf7a5eb70c5b1e".to_string())
         );
         assert!(monitors[0].filter_script.contains("Transfer"));
         assert_eq!(monitors[0].id, 0); // Default value from serde
 
-        // Check second monitor
+        // Check second monitor (with address)
         assert_eq!(monitors[1].name, "DEX Swap Monitor");
         assert_eq!(monitors[1].network, "ethereum");
         assert_eq!(
             monitors[1].address,
-            "0x7a250d5630b4cf539739df2c5dacb4c659f2488d"
+            Some("0x7a250d5630b4cf539739df2c5dacb4c659f2488d".to_string())
         );
         assert_eq!(monitors[1].filter_script, "log.name == \"Swap\"");
+
+        // Check third monitor (without address)
+        assert_eq!(monitors[2].name, "Native ETH Transfer Monitor");
+        assert_eq!(monitors[2].network, "ethereum");
+        assert_eq!(monitors[2].address, None);
+        assert_eq!(
+            monitors[2].filter_script,
+            "bigint(tx.value) > bigint(\"1000000000000000000\")"
+        );
     }
 
     #[test]
@@ -138,7 +151,7 @@ monitors:
 
         assert!(result.is_ok());
         let monitors = result.unwrap();
-        assert_eq!(monitors.len(), 2);
+        assert_eq!(monitors.len(), 3);
     }
 
     #[test]

--- a/src/engine/block_processor.rs
+++ b/src/engine/block_processor.rs
@@ -70,7 +70,7 @@ impl BlockProcessor {
                         match self.abi_service.decode_log(log) {
                             Ok(decoded) => decoded_logs.push(decoded),
                             Err(e) => {
-                                tracing::trace!(
+                                tracing::warn!(
                                     log_address = %log.address(),
                                     log_topics = ?log.topics(),
                                     error = %e,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,9 +28,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Load monitors from the configuration file if specified. This will overwrite
     // existing monitors for the same network in the database.
-    if let Some(monitor_config_path) = &config.monitor_config_path
-        && let Err(e) =
-            load_monitors_from_file(repo.as_ref(), &config.network_id, monitor_config_path).await
+    if let Err(e) =
+        load_monitors_from_file(repo.as_ref(), &config.network_id, &config.monitor_config_path).await
     {
         tracing::error!(error = %e, "Failed to load monitors from file, continuing with monitors already in database (if any).");
     }

--- a/src/supervisor/builder.rs
+++ b/src/supervisor/builder.rs
@@ -70,7 +70,7 @@ impl SupervisorBuilder {
         tracing::debug!(network_id = %config.network_id, "Loading monitors from database for filtering engine...");
         let monitors = state.get_monitors(&config.network_id).await?;
         tracing::info!(count = monitors.len(), network_id = %config.network_id, "Loaded monitors from database for filtering engine.");
-        let filtering_engine = RhaiFilteringEngine::new(monitors, config.rhai.clone());
+        let filtering_engine = RhaiFilteringEngine::new(monitors, config.rhai.clone())?;
 
         // Finally, construct the Supervisor with all its components.
         Ok(Supervisor::new(

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     config::AppConfig,
     engine::{
         block_processor::{BlockProcessor, BlockProcessorError},
-        filtering::FilteringEngine,
+        filtering::{FilteringEngine, MonitorValidationError},
     },
     models::{BlockData, DecodedBlockData},
     persistence::traits::StateRepository,
@@ -64,6 +64,10 @@ pub enum SupervisorError {
     /// The channel for communicating with a downstream service was closed unexpectedly.
     #[error("Channel closed")]
     ChannelClosed,
+
+    /// An error occurred during monitor validation.
+    #[error("Monitor validation error: {0}")]
+    MonitorValidationError(#[from] MonitorValidationError),
 }
 
 /// The primary runtime manager for the application.


### PR DESCRIPTION
- make `monitor_config_path` mandatory on `config.yaml`
- include `monitors.example.yaml` and make `address` field optional for a monitor
- add basic temporary monitor validation in `FilteringEngine` (will create a dedicated module next)