### PR TITLE
fix: rename max_retries to max_retry in HttpRetryConfig

### DIFF
--- a/configs/notifiers.example.yaml
+++ b/configs/notifiers.example.yaml
@@ -172,7 +172,7 @@ notifiers:
       # (Optional) Custom retry policy.
       retry_policy:
         # Maximum number of retries.
-        max_retries: 5
+        max_retry: 5
         # Initial delay between retries in milliseconds.
         initial_delay_ms: 100
         # Factor by which the delay increases after each retry (e.g., 2.0 for exponential backoff).

--- a/src/config/http_retry.rs
+++ b/src/config/http_retry.rs
@@ -41,7 +41,7 @@ pub enum JitterSetting {
 pub struct HttpRetryConfig {
     /// Maximum number of retries for transient errors
     #[serde(default = "default_max_attempts")]
-    pub max_retries: u32,
+    pub max_retry: u32,
     /// Base duration for exponential backoff calculations
     #[serde(default = "default_base_for_backoff")]
     pub base_for_backoff: u32,
@@ -68,7 +68,7 @@ impl Default for HttpRetryConfig {
     /// Creates a default configuration with reasonable retry settings
     fn default() -> Self {
         Self {
-            max_retries: default_max_attempts(),
+            max_retry: default_max_attempts(),
             base_for_backoff: default_base_for_backoff(),
             initial_backoff_ms: default_initial_backoff_ms(),
             max_backoff_secs: default_max_backoff_ms(),
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn test_http_retry_config_with_custom_values() {
         let yaml = "
-            max_retries: 5
+            max_retry: 5
             base_for_backoff: 100
             initial_backoff_ms: 200
             max_backoff_secs: 10
@@ -99,7 +99,7 @@ mod tests {
             Config::builder().add_source(config::File::from_str(yaml, config::FileFormat::Yaml));
         let config: HttpRetryConfig = builder.build().unwrap().try_deserialize().unwrap();
 
-        assert_eq!(config.max_retries, 5);
+        assert_eq!(config.max_retry, 5);
         assert_eq!(config.base_for_backoff, 100);
         assert_eq!(config.initial_backoff_ms, Duration::from_millis(200));
         assert_eq!(config.max_backoff_secs, Duration::from_secs(10));
@@ -115,7 +115,7 @@ mod tests {
             Config::builder().add_source(config::File::from_str(yaml, config::FileFormat::Yaml));
         let config: HttpRetryConfig = builder.build().unwrap().try_deserialize().unwrap();
 
-        assert_eq!(config.max_retries, default_config.max_retries);
+        assert_eq!(config.max_retry, default_config.max_retry);
         assert_eq!(config.base_for_backoff, default_config.base_for_backoff);
         assert_eq!(config.initial_backoff_ms, default_config.initial_backoff_ms);
         assert_eq!(config.max_backoff_secs, default_config.max_backoff_secs);

--- a/src/http_client/client.rs
+++ b/src/http_client/client.rs
@@ -29,7 +29,7 @@ pub fn create_retryable_http_client(
     let retry_policy = policy_builder
         .base(config.base_for_backoff)
         .retry_bounds(config.initial_backoff_ms, config.max_backoff_secs)
-        .build_with_max_retries(config.max_retries);
+        .build_with_max_retries(config.max_retry);
 
     ClientBuilder::new(base_client)
         .with(RetryTransientMiddleware::new_with_policy(retry_policy))

--- a/src/http_client/pool.rs
+++ b/src/http_client/pool.rs
@@ -205,7 +205,7 @@ mod tests {
         let retry_config_1 = HttpRetryConfig::default();
 
         // Config 2 (different retry count)
-        let retry_config_2 = HttpRetryConfig { max_retries: 5, ..Default::default() };
+        let retry_config_2 = HttpRetryConfig { max_retry: 5, ..Default::default() };
 
         // Get a client for each config
         let client1 = pool.get_or_create(&retry_config_1).await.unwrap();

--- a/tests/notification.rs
+++ b/tests/notification.rs
@@ -65,7 +65,7 @@ async fn test_success() {
 async fn test_failure_with_retryable_error() {
     let mut server = mockito::Server::new_async().await;
 
-    let retry_policy = HttpRetryConfig { max_retries: 2, ..Default::default() };
+    let retry_policy = HttpRetryConfig { max_retry: 2, ..Default::default() };
 
     let mock_discord_notifier = NotifierConfig {
         name: "test_discord_retry".to_string(),
@@ -116,7 +116,7 @@ async fn test_failure_with_retryable_error() {
 async fn test_failure_with_non_retryable_error() {
     let mut server = mockito::Server::new_async().await;
 
-    let retry_policy = HttpRetryConfig { max_retries: 3, ..Default::default() };
+    let retry_policy = HttpRetryConfig { max_retry: 3, ..Default::default() };
 
     let mock_discord_notifier = NotifierConfig {
         name: "test_discord_no_retry".to_string(),
@@ -172,7 +172,7 @@ async fn test_failure_with_invalid_url() {
                 body: "This should fail".to_string(),
             },
             retry_policy: HttpRetryConfig {
-                max_retries: 0,
+                max_retry: 0,
                 initial_backoff_ms: std::time::Duration::from_millis(1),
                 ..Default::default()
             },


### PR DESCRIPTION
# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
- [ ] Add integration tests if applicable.
- [ ] Update documentation if applicable.
